### PR TITLE
Fix Ruby 2.7 Deprecations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_gem:
   relaxed-rubocop: .rubocop.yml
 
+AllCops:
+  TargetRubyVersion: 2.3
+
 Style/Alias:
   Enabled: false
   StyleGuide: https://relaxed.ruby.style/#stylealias
@@ -163,7 +166,7 @@ Metrics/ModuleLength:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/MethodLength:
@@ -181,7 +184,7 @@ Style/GuardClause:
 Metrics/BlockLength:
   Enabled: false
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
@@ -229,19 +232,19 @@ Style/MissingRespondToMissing:
 Style/MultilineTernaryOperator:
   Enabled: false
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: false
 
 Style/RedundantSelf:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: false
 
 Layout/EmptyLinesAroundClassBody:
@@ -262,9 +265,6 @@ Style/RaiseArgs:
 Layout/SpaceAroundOperators:
   Enabled: false
 
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 Layout/EmptyLines:
   Enabled: false
 
@@ -277,7 +277,7 @@ Layout/ExtraSpacing:
 Style/SafeNavigation:
   Enabled: false
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: false
 
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
@@ -304,10 +304,10 @@ Style/LineEndConcatenation:
 Style/StructInheritance:
   Enabled: false
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: false
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: false
 
 Style/ExpandPathArguments:
@@ -325,7 +325,7 @@ Layout/RescueEnsureAlignment:
 Layout/SpaceInsideStringInterpolation:
   Enabled: false
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: false
 
 Lint/UnderscorePrefixedVariableName:
@@ -352,7 +352,7 @@ Style/RegexpLiteral:
 Gemspec/OrderedDependencies:
   Enabled: false
 
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   Enabled: false
 
 Layout/ClosingParenthesisIndentation:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
 - 2.4.6
 - 2.5.5
 - 2.6.3
+- 2.7.1
 notifications:
   email:
     recipients:

--- a/lib/sym/app/password/cache.rb
+++ b/lib/sym/app/password/cache.rb
@@ -36,7 +36,7 @@ module Sym
           self.enabled = opts[:enabled]
           self.verbose = opts[:verbose]
           self.timeout = opts[:timeout] || ::Sym::Configuration.config.password_cache_timeout
-          self.provider = Providers.provider(opts[:provider], opts[:provider_opts] || {})
+          self.provider = Providers.provider(opts[:provider], **(opts[:provider_opts] || {}))
           self.enabled = false unless self.provider
           self
         end

--- a/lib/sym/application.rb
+++ b/lib/sym/application.rb
@@ -177,7 +177,7 @@ module Sym
       args[:verbose]  = opts[:verbose]
       args[:provider] = opts[:cache_provider] if opts[:cache_provider]
 
-      self.password_cache = Sym::App::Password::Cache.instance.configure(args)
+      self.password_cache = Sym::App::Password::Cache.instance.configure(**args)
     end
 
     def process_edit_option

--- a/lib/sym/data/wrapper_struct.rb
+++ b/lib/sym/data/wrapper_struct.rb
@@ -9,6 +9,7 @@ module Sym
       :version,               # [Integer] Version of the cipher used
       :compress               # [Boolean] indicates if compression should be applied
       )
+      define_singleton_method(:new, Class.method(:new))
 
       VERSION = 1
 

--- a/sym.gemspec
+++ b/sym.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'relaxed-rubocop'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rspec-its'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '0.81.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
Fixes #24 

Minor changes to correct deprecations surrounding assuming keyword args.  Note that there is currently a bug in Ruby 2.7 that causes issues with the `WrapperStruct` that requires a hacky solution (see: https://github.com/ruby/ruby/pull/3045).