### PR TITLE
Fix remaining 2.7 warnings; memcached & keychain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ jobs:
     docker:
       # specify the version you desire here
        - image: circleci/ruby:2.6.2-node-browsers-legacy
-         environment: 
+         environment:
             TEST_DRB: false
 
        - image: memcached:latest
-      
+
     working_directory: ~/repo
 
     steps:
@@ -30,8 +30,8 @@ jobs:
           paths:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile" }}
-        
-      - run: 
+
+      - run:
           name: install dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
@@ -44,6 +44,7 @@ jobs:
       - run:
           name: RSpecs
           command: |
+            export PATH=".:$PATH"
             bundle exec rspec --version
             bundle exec exe/sym --version
             # flush memcached

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,16 +42,16 @@ jobs:
           command: dockerize -wait tcp://localhost:11211 -timeout 1m
 
       - run:
-          name: run specs
+          name: RSpecs
           command: |
             bundle exec rspec --version
             bundle exec exe/sym --version
             # flush memcached
-            echo flush_all | timeout -k 2 -s HUP 10 nc -G 4 127.0.0.1 11211 || true
+            printf "flush_all\r\nquit\r\n" | timeout -k 2 -s HUP 10 nc -G 4 127.0.0.1 11211 || true
             timeout -k 2 -s HUP 30 bundle exec rspec --order random --backtrace
 
       - run:
-          name: run rubocop
+          name: Rubocop
           command: |
             bundle exec rubocop --version
             bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -361,3 +361,18 @@ Layout/ClosingParenthesisIndentation:
 Layout/EmptyLineBetweenDefs:
   Enabled: false
 
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_gem:
   relaxed-rubocop: .rubocop.yml
 
+AllCops:
+  TargetRubyVersion: 2.3
+
 Style/Alias:
   Enabled: false
   StyleGuide: https://relaxed.ruby.style/#stylealias
@@ -163,7 +166,7 @@ Metrics/ModuleLength:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/MethodLength:
@@ -181,7 +184,7 @@ Style/GuardClause:
 Metrics/BlockLength:
   Enabled: false
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
@@ -229,19 +232,19 @@ Style/MissingRespondToMissing:
 Style/MultilineTernaryOperator:
   Enabled: false
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: false
 
 Style/RedundantSelf:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: false
 
 Layout/EmptyLinesAroundClassBody:
@@ -262,9 +265,6 @@ Style/RaiseArgs:
 Layout/SpaceAroundOperators:
   Enabled: false
 
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 Layout/EmptyLines:
   Enabled: false
 
@@ -277,7 +277,7 @@ Layout/ExtraSpacing:
 Style/SafeNavigation:
   Enabled: false
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: false
 
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
@@ -304,10 +304,10 @@ Style/LineEndConcatenation:
 Style/StructInheritance:
   Enabled: false
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: false
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: false
 
 Style/ExpandPathArguments:
@@ -325,7 +325,7 @@ Layout/RescueEnsureAlignment:
 Layout/SpaceInsideStringInterpolation:
   Enabled: false
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: false
 
 Lint/UnderscorePrefixedVariableName:
@@ -352,7 +352,7 @@ Style/RegexpLiteral:
 Gemspec/OrderedDependencies:
   Enabled: false
 
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   Enabled: false
 
 Layout/ClosingParenthesisIndentation:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
 - 2.4.6
 - 2.5.5
 - 2.6.3
+- 2.7.1
 notifications:
   email:
     recipients:

--- a/exe/sym
+++ b/exe/sym
@@ -1,5 +1,8 @@
-#!/usr/bin/env ruby
-# vim:filetype=ruby
+#!/usr/bin/env ruby -W0
+# vim: ft=ruby
+#
+
+require_relative '../lib/ruby_warnings'
 
 lib_path = File.expand_path(File.dirname(__FILE__) + '/../lib')
 $LOAD_PATH << lib_path if File.exist?(lib_path) && !$LOAD_PATH.include?(lib_path)

--- a/exe/sym
+++ b/exe/sym
@@ -1,6 +1,5 @@
-#!/usr/bin/env ruby -W0
+#!/usr/bin/env ruby
 # vim: ft=ruby
-#
 
 require_relative '../lib/ruby_warnings'
 

--- a/lib/ruby_warnings.rb
+++ b/lib/ruby_warnings.rb
@@ -1,0 +1,7 @@
+ruby_version = RbConfig::CONFIG['MAJOR'].to_i * 10 + RbConfig::CONFIG['MINOR'].to_i
+if ruby_version >= 27
+  Warning[:deprecated] = false
+  ENV['RUBYOPT'] = '-W:no-deprecated'
+else
+  ENV['RUBYOPT']="-W0"
+end

--- a/lib/sym/app/keychain.rb
+++ b/lib/sym/app/keychain.rb
@@ -43,7 +43,7 @@ module Sym
       end
 
       def add(password)
-        delete
+        delete rescue nil
         execute command(:add, " -T /usr/bin/security -w '#{password}' ")
       end
 
@@ -61,7 +61,7 @@ module Sym
         output = `#{command}`
         result = $?
         unless result.success?
-          STDERR.puts "> ERROR running command:\n> #{output.red}" if !stderr_disabled && opts[:verbose]
+          warn "> ERROR running command:\n>   $ #{output.red}" if !stderr_disabled && opts[:verbose]
           raise Sym::Errors::KeyChainCommandError.new("Command error: #{result}, command: #{command}")
         end
 

--- a/lib/sym/app/password/cache.rb
+++ b/lib/sym/app/password/cache.rb
@@ -36,7 +36,7 @@ module Sym
           self.enabled = opts[:enabled]
           self.verbose = opts[:verbose]
           self.timeout = opts[:timeout] || ::Sym::Configuration.config.password_cache_timeout
-          self.provider = Providers.provider(opts[:provider], opts[:provider_opts] || {})
+          self.provider = Providers.provider(opts[:provider], **(opts[:provider_opts] || {}))
           self.enabled = false unless self.provider
           self
         end

--- a/lib/sym/application.rb
+++ b/lib/sym/application.rb
@@ -177,7 +177,7 @@ module Sym
       args[:verbose]  = opts[:verbose]
       args[:provider] = opts[:cache_provider] if opts[:cache_provider]
 
-      self.password_cache = Sym::App::Password::Cache.instance.configure(args)
+      self.password_cache = Sym::App::Password::Cache.instance.configure(**args)
     end
 
     def process_edit_option

--- a/lib/sym/data/wrapper_struct.rb
+++ b/lib/sym/data/wrapper_struct.rb
@@ -9,6 +9,7 @@ module Sym
       :version,               # [Integer] Version of the cipher used
       :compress               # [Boolean] indicates if compression should be applied
       )
+      define_singleton_method(:new, Class.method(:new))
 
       VERSION = 1
 

--- a/lib/sym/data/wrapper_struct.rb
+++ b/lib/sym/data/wrapper_struct.rb
@@ -2,13 +2,20 @@ require 'sym/errors'
 module Sym
   module Data
     class WrapperStruct < Struct.new(
-      :encrypted_data,        # [Blob] Binary encrypted data (possibly compressed)
-      :iv,                    # [String] IV used to encrypt the data
-      :cipher_name,           # [String] Name of the cipher used
-      :salt,                  # [Integer] For password-encrypted data this is the salt
-      :version,               # [Integer] Version of the cipher used
-      :compress               # [Boolean] indicates if compression should be applied
-      )
+      # [Blob] Binary encrypted data (possibly compressed)s
+      :encrypted_data,
+      # [String] IV used to encrypt the datas
+      :iv,
+      # [String] Name of the cipher used
+      :cipher_name,
+      # [Integer] For password-encrypted data this is the salt
+      :salt,
+      # [Integer] Version of the cipher used
+      :version,
+      # [Boolean] indicates if compression should be applied
+      :compress
+    )
+
       define_singleton_method(:new, Class.method(:new))
 
       VERSION = 1
@@ -16,11 +23,11 @@ module Sym
       attr_accessor :compressed
 
       def initialize(
-        encrypted_data:, # [Blob] Binary encrypted data (possibly compressed)
-        iv:, # [String] IV used to encrypt the data
-        cipher_name:, # [String] Name of the cipher used
-        salt: nil, # [Integer] For password-encrypted data this is the salt
-        version: VERSION, # [Integer] Version of the cipher used
+        encrypted_data:,
+        iv:,
+        cipher_name:,
+        salt: nil,
+        version: VERSION,
         compress: Sym::Configuration.config.compression_enabled
       )
         super(encrypted_data, iv, cipher_name, salt, version, compress)

--- a/lib/sym/extensions/instance_methods.rb
+++ b/lib/sym/extensions/instance_methods.rb
@@ -87,12 +87,12 @@ module Sym
         block.call(cipher_struct) if block
 
         encrypted_data = update_cipher(cipher_struct.cipher, data)
-        wrapper_struct = WrapperStruct.new(
-          encrypted_data: encrypted_data,
-          iv:             cipher_struct.iv,
-          cipher_name:    cipher_struct.cipher.name,
-          salt:           cipher_struct.salt,
-          compress:       !compression_enabled)
+        arguments      = { encrypted_data: encrypted_data,
+                           iv:             cipher_struct.iv,
+                           cipher_name:    cipher_struct.cipher.name,
+                           salt:           cipher_struct.salt,
+                           compress:       !compression_enabled }
+        wrapper_struct = WrapperStruct.new(arguments)
         encode(wrapper_struct, false)
       end
 
@@ -106,7 +106,6 @@ module Sym
         block.call(cipher_struct) if block
         decode(update_cipher(cipher_struct.cipher, wrapper_struct.encrypted_data))
       end
-
 
       def encode_incoming_data(data)
         compression_enabled = !data.respond_to?(:size) || (data.size > 100 && encryption_config.compression_enabled)

--- a/spec/integration/sym_cli_spec.rb
+++ b/spec/integration/sym_cli_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'CLI execution', :type => :aruba do
   RESET_TEMP_FILE.call
 
   context 'using Aruba framework' do
-    let(:command) { "exe/sym #{args}" }
+    let(:command) { "./exe/sym #{args}" }
     let(:output) { last_command_started.stdout.chomp }
 
     context 'install bash completion' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require_relative '../lib/ruby_warnings'
 require 'simplecov'
 SimpleCov.start
 
@@ -30,7 +31,7 @@ end
 
 Kernel.class_eval do
   def clear_memcached!
-    `echo flush_all | nc -G 2 127.0.0.1 11211 2>/dev/null`
+    `printf "flush_all\\r\\nquit\\r\\n" | nc -G 2 127.0.0.1 11211 2>/dev/null`
     $?.exitstatus == 0
   end
 end

--- a/spec/support/aruba.rb
+++ b/spec/support/aruba.rb
@@ -3,8 +3,6 @@ require 'aruba/processes/in_process'
 require 'sym/app/cli'
 
 Aruba.configure do |config|
-  unless ENV['CI']
-    config.command_launcher = :in_process
-    config.main_class = Sym::App::CLI
-  end
+  config.command_launcher = :in_process
+  config.main_class       = Sym::App::CLI
 end

--- a/spec/sym/app/keychain_spec.rb
+++ b/spec/sym/app/keychain_spec.rb
@@ -37,15 +37,18 @@ module Sym
         context 'integration tests' do
           before do
             keychain.stderr_off
-            keychain.delete rescue nil  # delete in case it's already there
+            keychain.delete rescue nil
+            sleep 0.1
+            keychain.add(password)
           end
+
           after do
             keychain.stderr_on
           end
+
           it 'should add a new key' do
-            keychain.add(password)
+            sleep 0.1
             expect(keychain.find).to eql(password)
-            keychain.delete
           end
         end
       end

--- a/spec/sym/data_spec.rb
+++ b/spec/sym/data_spec.rb
@@ -5,7 +5,8 @@ module Sym
     RSpec.describe 'Sym::Data' do
       let(:iv) { OpenSSL::Random.random_bytes 16 }
       let(:cipher_name) { Sym::Configuration.property(:data_cipher) }
-      let(:ws) { WrapperStruct.new(encrypted_data: 1234, iv: iv, cipher_name: cipher_name, salt: 'Boo') }
+      let(:args) { { encrypted_data: 1234, iv: iv, cipher_name: cipher_name, salt: 'Boo' } }
+      let(:ws) { WrapperStruct.new(args) }
 
       context 'WrapperStruct' do
 

--- a/sym.gemspec
+++ b/sym.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'relaxed-rubocop'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rspec-its'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '0.81.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
 * memcached was hanging in specs because we were not sending "QUIT"

 * keychain in Catalina now asks for password when a generic password
   is getting updated (overwriting an existing one). To bypass this
   we are now deleting before adding, and not using -U updated flag.

 * Fixed 2.7 warnings by setting appropriate flags

This PR incorporates changes from #26 & fixes #24 